### PR TITLE
Rename oscillation labels

### DIFF
--- a/dist/duux-whisper-flex-card.js
+++ b/dist/duux-whisper-flex-card.js
@@ -59,7 +59,7 @@ let DuuxWhisperFlexCard = class DuuxWhisperFlexCard extends LitElement {
           <span>Fan ${fanEntity.state === "on" ? "On" : "Off"}</span>
         </div>
         <div class="row">
-          <span>Horizontal Oscillation:</span>
+          <span>Swing:</span>
           ${swingOptions.map((opt) => html `
               <button
                 class="button ${swing === opt.value ? 'active' : ''}"
@@ -70,7 +70,7 @@ let DuuxWhisperFlexCard = class DuuxWhisperFlexCard extends LitElement {
             `)}
         </div>
         <div class="row">
-          <span>Vertical Oscillation:</span>
+          <span>Tilt:</span>
           ${tiltOptions.map((opt) => html `
               <button
                 class="button ${tilt === opt.value ? 'active' : ''}"

--- a/src/duux-whisper-flex-card.ts
+++ b/src/duux-whisper-flex-card.ts
@@ -93,7 +93,7 @@ export class DuuxWhisperFlexCard extends LitElement {
           <span>Fan ${fanEntity.state === "on" ? "On" : "Off"}</span>
         </div>
         <div class="row">
-          <span>Horizontal Oscillation:</span>
+          <span>Swing:</span>
           ${swingOptions.map(
             (opt) => html`
               <button
@@ -106,7 +106,7 @@ export class DuuxWhisperFlexCard extends LitElement {
           )}
         </div>
         <div class="row">
-          <span>Vertical Oscillation:</span>
+          <span>Tilt:</span>
           ${tiltOptions.map(
             (opt) => html`
               <button


### PR DESCRIPTION
## Summary
- rename Horizontal Oscillation to Swing
- rename Vertical Oscillation to Tilt

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_684ffd0b8f1c8324800ddbcca21f0974