### PR TITLE
Adjust visual layout to match Home Assistant

### DIFF
--- a/dist/duux-whisper-flex-card.js
+++ b/dist/duux-whisper-flex-card.js
@@ -51,15 +51,15 @@ let DuuxWhisperFlexCard = class DuuxWhisperFlexCard extends LitElement {
         ];
         return html `
       <ha-card header="Duux Whisper Flex">
-        <div class="row">
+        <div class="row fan-row">
+          <ha-icon icon="mdi:fan"></ha-icon>
           <ha-switch
             .checked=${fanEntity.state === "on"}
             @change=${(e) => this._toggleFan(e)}
           ></ha-switch>
-          <span>Fan ${fanEntity.state === "on" ? "On" : "Off"}</span>
         </div>
-        <div class="row">
-          <span>Swing:</span>
+        <div class="row option-row">
+          <span class="label">Swing</span>
           ${swingOptions.map((opt) => html `
               <button
                 class="button ${swing === opt.value ? 'active' : ''}"
@@ -69,8 +69,8 @@ let DuuxWhisperFlexCard = class DuuxWhisperFlexCard extends LitElement {
               </button>
             `)}
         </div>
-        <div class="row">
-          <span>Tilt:</span>
+        <div class="row option-row">
+          <span class="label">Tilt</span>
           ${tiltOptions.map((opt) => html `
               <button
                 class="button ${tilt === opt.value ? 'active' : ''}"
@@ -80,18 +80,20 @@ let DuuxWhisperFlexCard = class DuuxWhisperFlexCard extends LitElement {
               </button>
             `)}
         </div>
-        <div class="row">
-          <span>Speed:</span>
-          <input
-            type="range"
-            class="slider"
-            min="1"
-            max="30"
-            .value=${speed}
-            @input=${(e) => this._updateSpeed(e.target.value)}
-            @change=${(e) => this._setSpeed(e.target.value)}
-          />
-          <span>${speed}</span>
+        <div class="row speed-row">
+          <span class="speed-label label">Speed</span>
+          <div class="speed-control">
+            <input
+              type="range"
+              class="slider"
+              min="1"
+              max="30"
+              .value=${speed}
+              @input=${(e) => this._updateSpeed(e.target.value)}
+              @change=${(e) => this._setSpeed(e.target.value)}
+            />
+            <span class="speed-value">${speed}</span>
+          </div>
         </div>
       </ha-card>
     `;
@@ -157,7 +159,20 @@ DuuxWhisperFlexCard.styles = css `
     .row {
       display: flex;
       align-items: center;
-      margin-bottom: 8px;
+      padding: 8px 16px;
+      margin: 0;
+    }
+    .row + .row {
+      margin-top: 4px;
+    }
+    .label {
+      flex: 0 0 72px;
+    }
+    ha-icon {
+      margin-right: 16px;
+    }
+    .fan-row ha-switch {
+      margin-left: auto;
     }
     .button {
       padding: 6px 12px;
@@ -170,6 +185,22 @@ DuuxWhisperFlexCard.styles = css `
     }
     .slider {
       width: 100%;
+    }
+    .speed-row {
+      flex-direction: column;
+      align-items: stretch;
+    }
+    .speed-control {
+      display: flex;
+      align-items: center;
+    }
+    .speed-control .slider {
+      flex: 1;
+      margin-right: 16px;
+    }
+    .speed-value {
+      width: 32px;
+      text-align: right;
     }
   `;
 __decorate([

--- a/src/duux-whisper-flex-card.ts
+++ b/src/duux-whisper-flex-card.ts
@@ -27,7 +27,20 @@ export class DuuxWhisperFlexCard extends LitElement {
     .row {
       display: flex;
       align-items: center;
-      margin-bottom: 8px;
+      padding: 8px 16px;
+      margin: 0;
+    }
+    .row + .row {
+      margin-top: 4px;
+    }
+    .label {
+      flex: 0 0 72px;
+    }
+    ha-icon {
+      margin-right: 16px;
+    }
+    .fan-row ha-switch {
+      margin-left: auto;
     }
     .button {
       padding: 6px 12px;
@@ -40,6 +53,22 @@ export class DuuxWhisperFlexCard extends LitElement {
     }
     .slider {
       width: 100%;
+    }
+    .speed-row {
+      flex-direction: column;
+      align-items: stretch;
+    }
+    .speed-control {
+      display: flex;
+      align-items: center;
+    }
+    .speed-control .slider {
+      flex: 1;
+      margin-right: 16px;
+    }
+    .speed-value {
+      width: 32px;
+      text-align: right;
     }
   `;
 
@@ -85,15 +114,15 @@ export class DuuxWhisperFlexCard extends LitElement {
 
     return html`
       <ha-card header="Duux Whisper Flex">
-        <div class="row">
+        <div class="row fan-row">
+          <ha-icon icon="mdi:fan"></ha-icon>
           <ha-switch
             .checked=${fanEntity.state === "on"}
             @change=${(e: Event) => this._toggleFan(e)}
           ></ha-switch>
-          <span>Fan ${fanEntity.state === "on" ? "On" : "Off"}</span>
         </div>
-        <div class="row">
-          <span>Swing:</span>
+        <div class="row option-row">
+          <span class="label">Swing</span>
           ${swingOptions.map(
             (opt) => html`
               <button
@@ -105,8 +134,8 @@ export class DuuxWhisperFlexCard extends LitElement {
             `
           )}
         </div>
-        <div class="row">
-          <span>Tilt:</span>
+        <div class="row option-row">
+          <span class="label">Tilt</span>
           ${tiltOptions.map(
             (opt) => html`
               <button
@@ -118,18 +147,20 @@ export class DuuxWhisperFlexCard extends LitElement {
             `
           )}
         </div>
-        <div class="row">
-          <span>Speed:</span>
-          <input
-            type="range"
-            class="slider"
-            min="1"
-            max="30"
-            .value=${speed}
-            @input=${(e: Event) => this._updateSpeed((e.target as HTMLInputElement).value)}
-            @change=${(e: Event) => this._setSpeed((e.target as HTMLInputElement).value)}
-          />
-          <span>${speed}</span>
+        <div class="row speed-row">
+          <span class="speed-label label">Speed</span>
+          <div class="speed-control">
+            <input
+              type="range"
+              class="slider"
+              min="1"
+              max="30"
+              .value=${speed}
+              @input=${(e: Event) => this._updateSpeed((e.target as HTMLInputElement).value)}
+              @change=${(e: Event) => this._setSpeed((e.target as HTMLInputElement).value)}
+            />
+            <span class="speed-value">${speed}</span>
+          </div>
         </div>
       </ha-card>
     `;


### PR DESCRIPTION
## Summary
- style card rows like native Home Assistant
- align labels and move toggle and slider

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_685004ed7128832484dfe05edde77c29