### PR TITLE
Update speed label and spacing

### DIFF
--- a/dist/duux-whisper-flex-card.js
+++ b/dist/duux-whisper-flex-card.js
@@ -81,7 +81,7 @@ let DuuxWhisperFlexCard = class DuuxWhisperFlexCard extends LitElement {
             `)}
         </div>
         <div class="row speed-row">
-          <span class="speed-label label">Speed</span>
+          <span class="speed-label label">Fan speed</span>
           <div class="speed-control">
             <input
               type="range"
@@ -189,6 +189,7 @@ DuuxWhisperFlexCard.styles = css `
     .speed-row {
       flex-direction: column;
       align-items: stretch;
+      gap: 4px;
     }
     .speed-control {
       display: flex;

--- a/src/duux-whisper-flex-card.ts
+++ b/src/duux-whisper-flex-card.ts
@@ -57,6 +57,7 @@ export class DuuxWhisperFlexCard extends LitElement {
     .speed-row {
       flex-direction: column;
       align-items: stretch;
+      gap: 4px;
     }
     .speed-control {
       display: flex;
@@ -148,7 +149,7 @@ export class DuuxWhisperFlexCard extends LitElement {
           )}
         </div>
         <div class="row speed-row">
-          <span class="speed-label label">Speed</span>
+          <span class="speed-label label">Fan speed</span>
           <div class="speed-control">
             <input
               type="range"


### PR DESCRIPTION
## Summary
- change 'Speed' label to 'Fan speed'
- reduce distance between label and slider by adding `gap: 4px`

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68501ae3d4e88324b4ace255aa4a128b